### PR TITLE
Detect Combat task completions as Combat Achievements

### DIFF
--- a/src/main/java/com/clanchatwebhook/ClanChatWebhookPlugin.java
+++ b/src/main/java/com/clanchatwebhook/ClanChatWebhookPlugin.java
@@ -147,7 +147,7 @@ public class ClanChatWebhookPlugin extends Plugin
 				return SystemMessageType.LEVEL_UP;
 			} else if (message.contains("tier of rewards from Combat Achievements!")) {
 				return SystemMessageType.COMBAT_ACHIEVEMENTS;
-			} else if (message.contains("received a clue item:")) {
+			} else if (message.contains("received a clue item:") || (message.contains("has completed") && message.contains("combat task"))) {
 				return SystemMessageType.CLUE_DROP;
 			} else if (message.contains("has left.") || message.contains("has been invited into the clan by") || message.contains("has joined.")) {
 				return SystemMessageType.ATTENDANCE;

--- a/src/main/java/com/clanchatwebhook/ClanChatWebhookPlugin.java
+++ b/src/main/java/com/clanchatwebhook/ClanChatWebhookPlugin.java
@@ -145,9 +145,9 @@ public class ClanChatWebhookPlugin extends Plugin
 				return SystemMessageType.PET_DROP;
 			} else if ((message.contains("has reached") && (message.contains("level") || message.contains("XP"))) || message.contains("has reached a total level of")) {
 				return SystemMessageType.LEVEL_UP;
-			} else if (message.contains("tier of rewards from Combat Achievements!")) {
+			} else if (message.contains("tier of rewards from Combat Achievements!") || (message.contains("has completed") && message.contains("combat task"))) {
 				return SystemMessageType.COMBAT_ACHIEVEMENTS;
-			} else if (message.contains("received a clue item:") || (message.contains("has completed") && message.contains("combat task"))) {
+			} else if (message.contains("received a clue item:")) {
 				return SystemMessageType.CLUE_DROP;
 			} else if (message.contains("has left.") || message.contains("has been invited into the clan by") || message.contains("has joined.")) {
 				return SystemMessageType.ATTENDANCE;


### PR DESCRIPTION
When combat tasks get completed this shows up in discord as:
![image](https://github.com/user-attachments/assets/d105c3d7-d0eb-41f0-bf1f-6b1312140f77)
To stop this first detect the type as combat achievements instead of unknown. Next to that I've added a PR in the clanchat.net repo to remove this prefix.

https://github.com/pascalla/clanchat.net/pull/12